### PR TITLE
Add basic Flask web interface

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,3 +106,17 @@ The script supports downloading the following file types:
 
 - Ensure that the URL you provide points to a direct file download. If the URL does not point directly to a downloadable file, the script may return an error.
 - If you encounter issues, please check your internet connection and ensure the URL is valid.
+
+## Running the Web App
+
+A minimal Flask application is provided to trigger downloads from a browser.
+
+1. Install the required Python packages:
+   ```bash
+   pip install flask requests yt-dlp
+   ```
+2. Start the web server:
+   ```bash
+   python web_app.py
+   ```
+3. Open `http://127.0.0.1:5000` in your browser and submit the URL, path, and filename.

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>USAFE Downloader</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        label { display: block; margin-bottom: 10px; }
+        input { padding: 5px; width: 300px; }
+        button { padding: 5px 10px; margin-top: 10px; }
+        #message { margin-top: 20px; }
+    </style>
+</head>
+<body>
+<h1>USAFE Downloader</h1>
+<form id="download-form">
+    <label>URL:<br><input type="text" id="url" required></label>
+    <label>Path:<br><input type="text" id="path"></label>
+    <label>Filename:<br><input type="text" id="filename"></label>
+    <button type="submit">Download</button>
+</form>
+<div id="message"></div>
+<script>
+document.getElementById('download-form').addEventListener('submit', function(e) {
+    e.preventDefault();
+    const payload = {
+        url: document.getElementById('url').value,
+        path: document.getElementById('path').value,
+        filename: document.getElementById('filename').value
+    };
+    fetch('/download', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+    }).then(resp => resp.json())
+      .then(data => {
+          document.getElementById('message').innerText = data.message;
+      }).catch(() => {
+          document.getElementById('message').innerText = 'Error';
+      });
+});
+</script>
+</body>
+</html>

--- a/web_app.py
+++ b/web_app.py
@@ -1,0 +1,32 @@
+import os
+from flask import Flask, request, jsonify, render_template
+from USAFE_downloader import download_file, download_video
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/download', methods=['POST'])
+def download():
+    data = request.get_json(force=True)
+    url = data.get('url')
+    output_path = data.get('path') or os.getcwd()
+    filename = data.get('filename') or 'output'
+
+    if not os.path.exists(output_path):
+        os.makedirs(output_path)
+
+    lower_url = url.lower()
+    if lower_url.endswith('.pdf'):
+        download_file(url, output_path, filename + '.pdf')
+    elif lower_url.endswith(('.mp3', '.mp4', '.avi', '.mkv', '.flv', '.mov')):
+        download_video(url, output_path, filename)
+    else:
+        download_video(url, output_path, filename)
+
+    return jsonify({'message': 'Download triggered'})
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- add `web_app.py` Flask server exposing `/download`
- create `templates/index.html` for simple input form
- document how to launch the new web app in README

## Testing
- `python -m py_compile web_app.py USAFE_downloader.py`

------
https://chatgpt.com/codex/tasks/task_e_686b79ad4e048330a1355ec2340ab2a1